### PR TITLE
fix: improve the bind sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@
 # vendor/
 
 bind_keystore/*
-*.json
 build/*
 .idea/*

--- a/script/bind.sh
+++ b/script/bind.sh
@@ -29,10 +29,16 @@ then
    nodeUrl="http://data-seed-pre-0-s3.binance.org:80"
 fi
 
-./build/token-bind-tool deployContract --config-path script/contract.json --network-type $networkType
+result=$(./build/token-bind-tool deployContract --config-path script/contract.json --network-type $networkType)
+# Check the exit status of the previous command
+if [ $? -ne 0 ]; then
+   echo $result
+    # The exit status is not 0, indicating an error
+   exit 1
+fi
 
-echo "Please input the new deploy bep20 contract address "
-read bep20ContractAddr
+bep20ContractAddr=$result
+echo "bep20ContractAddr: $bep20ContractAddr" 
 
 if [ $passwd == "" ]
 then
@@ -43,6 +49,11 @@ else
   echo $passwd | $binaryPath bridge bind --symbol $bep2TokenSymbol --amount $peggyAmount --expire-time `expr $(date +%s) + 3600` \
 --contract-decimals 18 --from $bep2TokenOwnerKeyName --chain-id $chainId --contract-address $bep20ContractAddr \
 --node $nodeUrl
+fi
+# Check the exit status of the previous command
+if [ $? -ne 0 ]; then
+    # The exit status is not 0, indicating an error
+   exit 1
 fi
 
 

--- a/script/contract.json
+++ b/script/contract.json
@@ -1,0 +1,3 @@
+{
+    "contract_data": "/* Replace this with the compiled bytecode of your contract. You can obtain it from Remix Compiler or by locally building it using a Solidity compiler. */"
+}


### PR DESCRIPTION
## Description
1. If an error occurs, the script will return
2. Leave the contract.json template
3. Automatically read the bep20 contract address when running `bind.sh`